### PR TITLE
In aspect-ratio mixin, only apply object-fit selectively

### DIFF
--- a/_cobalt.scss
+++ b/_cobalt.scss
@@ -183,7 +183,9 @@ $all-text-inputs: (
     width: 100%;
     height: 100%;
     margin: 0;
-    object-fit: cover;
+    @if $child == "img" or $child == "video" {
+      object-fit: cover;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes visual bug in Safari when object-fit is applied to iframe elements